### PR TITLE
(improvement):hide run button when on settings page

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -12,8 +12,11 @@
         &nbsp; CodeceptUI
       </b-navbar-item>
     </template>
-    <template slot="start">
-      <b-navbar-item>
+    <template slot="burger">
+      <b-navbar-item
+        tag="div"
+        v-if="this.$route.path !== '/settings'"
+      >
         <RunButton @run="run()" />
       </b-navbar-item>
     </template>


### PR DESCRIPTION
## Motivation/Description of the PR

Hide `Run` button on Settings page cause we don't execute tests on that page
<img width="824" alt="Screenshot 2019-11-29 at 11 57 41" src="https://user-images.githubusercontent.com/7845001/69864548-7af1fa00-129f-11ea-81d1-774fd1baa8d4.png">

## Type of change

- [ ] Breaking changes
- [ ] New functionality
- [ ] Bug fix
- [ ] Documentation changes/updates
- [ ] Hot fix
- [ ] Markdown files fix - not related to source code
- [x] Improvement

## Checklist:
- [x] Lint checking (Run `npm run lint`)