### PR TITLE
(enh):hide settings menu on config page

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -23,7 +23,7 @@
 
     <template slot="end">
       <b-navbar-item>
-        <SettingsMenu />
+        <SettingsMenu v-if="this.$route.path !== '/settings'" />
       </b-navbar-item>
       <bar-navbar-item />
     </template>


### PR DESCRIPTION
we could hide the settings icon on config page, cause we have nothing to do with it on that page.