### PR TITLE
fix error when navigating to config file while sitting on test page

### DIFF
--- a/src/components/SettingsMenu.vue
+++ b/src/components/SettingsMenu.vue
@@ -248,7 +248,7 @@ export default {
       this.$store.dispatch('settings/setHeadless', this.headlessMode);
     },
     gotoSettingsPage() {
-      this.$router.push('settings');
+      this.$router.push({path: '/settings'});
     }
   }
 };


### PR DESCRIPTION
### Status Quo

You won't be redirected to `settings` page when standing on the `testrun` page. You will get this error when checking the browser console log


> vue-router.esm.js?8c4f:2051 Uncaught (in promise) NavigationDuplicated {_name: "NavigationDuplicated", name: "NavigationDuplicated", message: "Navigating to current location ("/testrun/settings") is not allowed", stack: "Error↵    at new NavigationDuplicated (webpack-int…node_modules/vue/dist/vue.runtime.esm.js:1853:26)"}
