### PR TITLE
fix helper is required error when using only REST helper

### DIFF
--- a/lib/codeceptjs/realtime-reporter.helper.js
+++ b/lib/codeceptjs/realtime-reporter.helper.js
@@ -173,7 +173,7 @@ class RealtimeReporterHelper extends Helper {
   }
 
   _getHelper() {
-    return this.helpers['Appium'] || this.helpers['WebDriver'] || this.helpers['WebDriverIO'] || this.helpers['Puppeteer'] || this.helpers['TestCafe'];
+    return this.helpers['REST'] || this.helpers['Appium'] || this.helpers['WebDriver'] || this.helpers['WebDriverIO'] || this.helpers['Puppeteer'] || this.helpers['TestCafe'];
   }
 
   _generateSection(metaStep, append = false) {


### PR DESCRIPTION
In my tests, we have only REST helper in the codecept config and trying to execute the tests, you will get `helper is required` error. This PR aims to fix that issue.